### PR TITLE
Fixes handling of dates in controllers

### DIFF
--- a/controllers/todos.js
+++ b/controllers/todos.js
@@ -11,11 +11,11 @@ module.exports = {
     BASIC CRUD FIRST
     ////////////////////////*/
     getTodoPage: async (req, res) => {
+        const localeDate = new Date().toLocaleDateString()
         const lookUpDate = {
-            $gte: startOfDay(new Date()),
-            $lte: endOfDay(new Date())
+            $gte: startOfDay(new Date(localeDate)),
+            $lte: endOfDay(new Date(localeDate))
         }
-        const calendar = new Date()
         try {
             const todoItems = await Todo.find({
                 date: lookUpDate,
@@ -32,17 +32,17 @@ module.exports = {
                 pets: pets,
                 left: itemsLeft,
                 user: req.user,
-                calendar: calendar
+                calendar: new Date(localeDate),
+                localeDate: localeDate
             })
+            console.log(localeDate, new Date(localeDate))
         } catch (err) {
             console.error(err)
         }
     },
     createTodo: async (req, res) => {
         let creationDate = req.body.date.replace(/-/g, '/')
-        if (!creationDate) {
-            creationDate = new Date()
-        }
+
         const getDate = new Date(creationDate).toISOString().slice(0,10)
         try {
             await Todo.create({
@@ -145,66 +145,34 @@ module.exports = {
                 user: req.user,
                 calendar: date
             })
+            console.log(date)
+        } catch (err) {
+            console.error(err)
+        }
+    },
+    formTodosByDate: async (req, res) => {
+        let creationDate = req.body.date.replace(/-/g, '/')
+        const getDate = new Date(creationDate).toISOString().slice(0,10)
+        try {
+            res.redirect(`/todos/${getDate}`)
         } catch (err) {
             console.error(err)
         }
     },
     getPreviousDay: async (req, res) => {
         const date = new Date(req.body.date.replace(/-/g, '/'))
-        const previous = subDays(date, 1)
-        const lookUpDate = {
-            $gte: startOfDay(previous),
-            $lte: endOfDay(previous)
-        }
-        const calendar = previous
+        const previous = subDays(date, 1).toISOString().slice(0,10)
         try {
-            const todoItems = await Todo.find({
-                date: lookUpDate,
-                userId: req.user.id
-            }).lean()
-            const pets = await Pet.find({ userId: req.user.id })
-            const itemsLeft = await Todo.countDocuments({
-                userId: req.user.id,
-                completed: false,
-                date: lookUpDate
-            }).lean()
-            res.render('todos.ejs', {
-                todos: todoItems,
-                pets: pets,
-                left: itemsLeft,
-                user: req.user,
-                calendar: calendar
-            })
+            res.redirect(`/todos/${previous}`)
         } catch (err) {
             console.error(err)
         }
     },
     getNextDay: async (req, res) => {
         const date = new Date(req.body.date.replace(/-/g, '/'))
-        const next = addDays(date, 1)
-        const lookUpDate = {
-            $gte: startOfDay(next),
-            $lte: endOfDay(next)
-        }
-        const calendar = next
+        const next = addDays(date, 1).toISOString().slice(0,10)
         try {
-            const todoItems = await Todo.find({
-                date: lookUpDate,
-                userId: req.user.id
-            }).lean()
-            const pets = await Pet.find({ userId: req.user.id }).lean()
-            const itemsLeft = await Todo.countDocuments({
-                userId: req.user.id,
-                completed: false,
-                date: lookUpDate
-            }).lean()
-            res.render('todos.ejs', {
-                todos: todoItems,
-                pets: pets,
-                left: itemsLeft,
-                user: req.user,
-                calendar: calendar
-            })
+            res.redirect(`/todos/${next}`)
         } catch (err) {
             console.error(err)
         }

--- a/routes/todos.js
+++ b/routes/todos.js
@@ -7,7 +7,7 @@ router.get('/', ensureAuth, todosController.getTodoPage)
 router.get('/:date', ensureAuth, todosController.getTodosByDate)
 
 router.post('/createTodo', todosController.createTodo)
-router.post('/getDate', todosController.getTodosByDate)
+router.post('/getDate', todosController.formTodosByDate)
 router.post('/previous', todosController.getPreviousDay)
 router.post('/next', todosController.getNextDay)
 

--- a/views/calendar.ejs
+++ b/views/calendar.ejs
@@ -24,7 +24,7 @@
             <% todos.forEach( el=> { %>
               <tr scope="row">
                 <td class="py-md-4 py-sm-2">
-                  <a class="link-success" href="/todos/<%= new Date(el.date).toISOString().slice(0,10) %>"><%= el.date.toLocaleDateString('en', { year: 'numeric' , month: 'short' , day: '2-digit' }) %></a>
+                  <a class="link-success" href="/todos/<%= new Date(el.date).toISOString().slice(0,10) %>"><%= new Date(el.date).toLocaleDateString('en', { year: 'numeric' , month: 'long' , day: '2-digit' }) %></a>
                 </td>
                 <td class="list-group w-auto">
                   <div class="list-group-item list-group-item-action d-flex flex-column gap-3 py-md-3 py-sm-1 flex-wrap">

--- a/views/todos.ejs
+++ b/views/todos.ejs
@@ -31,10 +31,10 @@
   <div class="row mx-2 mb-4">
     <div class="col col-sm-12 col-md-10 col-lg-8 mx-auto">
       <div class="card">
-        <div class="card-header d-flex align-items-center">
-          <i class="fa-solid fa-list-check text-success fa-2xl align-self-baseline mt-2  me-3"></i>
+        <div class="card-header d-flex align-items-center px-2">
+          <i class="fa-solid fa-list-check text-success fa-xl align-self-baseline mt-2 pt-sm-1 me-1 me-sm-2"></i>
           <h1 class="fs-2 py-1">
-            <%= calendar.toLocaleDateString('en', { year: 'numeric' , month: 'short' , day: '2-digit' }) %>
+            <%= calendar.toLocaleDateString('en', { year: 'numeric' , month: 'long' , day: '2-digit' }) %>
           </h1>
         </div>
         


### PR DESCRIPTION
Problem:
* Depending on the time of the day, wrong timezone handling caused task creation dates to be incorrect.

Solution
* Adds locale date handling to the todos.js controller, so task date will now depend on JavaScript runtime locale.

Extra:
* Previous/next day and getting date by datepicker now all redirect to getTodoByDate. Controllers were cleaned up, and the POST /getDate route was updated.
  * i.e: instead of /todos/previous, now the request will redirect to /todos/yyyy-MM-dd

* Calendar and daily to-do list now display month name in full.